### PR TITLE
feat: wjt-3 - adds routing

### DIFF
--- a/apps/wjt/src/main.ts
+++ b/apps/wjt/src/main.ts
@@ -1,5 +1,6 @@
 import koa from 'koa';
 import serve from '@ladjs/koa-better-static';
+import { router } from './routes';
 
 const host = process.env.HOST ?? '0.0.0.0';
 const port = process.env.PORT ? Number(process.env.PORT) : 4200;
@@ -12,19 +13,7 @@ const app = new koa();
 app.use(async (ctx, next) => {
   return staticServe(ctx, next);
 });
-app.use(async (ctx) => {
-  ctx.body = `
-  <html>
-      <head>
-          <title>willjohnston.tech</title>
-          <link rel="icon" href="https://wjt.sfo2.cdn.digitaloceanspaces.com/wjt_logo.ico" />
-      </head>
-      <body>
-          <h1>willjohnston.tech</h1>
-      </body>
-  </html>
-  `;
-});
+app.use(router.routes());
 
 app.listen(port, host, () => {
   console.log(`[ ready ] http://${host}:${port}`);

--- a/apps/wjt/src/routes/index.ts
+++ b/apps/wjt/src/routes/index.ts
@@ -1,0 +1,8 @@
+import Router from '@koa/router';
+import { router as v1Router } from './v1';
+
+const router = new Router();
+
+router.use(v1Router.routes());
+
+export { router };

--- a/apps/wjt/src/routes/v1.ts
+++ b/apps/wjt/src/routes/v1.ts
@@ -1,0 +1,18 @@
+import Router from '@koa/router';
+import { Context } from 'koa';
+
+export const router = new Router();
+
+router.get('/', async (ctx: Context) => {
+  ctx.body = `
+      <html>
+          <head>
+              <title>willjohnston.tech</title>
+              <link rel="icon" href="https://wjt.sfo2.cdn.digitaloceanspaces.com/wjt_logo.ico" />
+          </head>
+          <body>
+              <h1>willjohnston.tech</h1>
+          </body>
+      </html>
+    `;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@koa/router": "^13.1.0",
         "@ladjs/koa-better-static": "^2.0.1",
         "axios": "^1.6.0",
         "koa": "~2.14.1"
@@ -3035,6 +3036,45 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@koa/router": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-13.1.0.tgz",
+      "integrity": "sha512-mNVu1nvkpSd8Q8gMebGbCkDWJ51ODetrFvLKYusej+V0ByD4btqHYnPIzTBLXnQMVUlm/oxVwqmWBY3zQfZilw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^6.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@koa/router/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@koa/router/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/@ladjs/koa-better-static": {
@@ -8447,6 +8487,12 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "private": true,
   "dependencies": {
+    "@koa/router": "^13.1.0",
     "@ladjs/koa-better-static": "^2.0.1",
     "axios": "^1.6.0",
     "koa": "~2.14.1"


### PR DESCRIPTION
This pull request introduces a new routing system to the `apps/wjt` application by integrating `@koa/router` and refactoring the main application and routes accordingly. The changes primarily involve setting up the router and moving the HTML response logic to a dedicated route file.

Key changes include:

### Routing Integration:

* [`apps/wjt/src/main.ts`](diffhunk://#diff-b4e33ba8306827567807c9af84dde99d2b0b6e045ae904a4709cdb119388fdaeR3): Imported the router from `./routes` and replaced the static HTML response with `router.routes()`. [[1]](diffhunk://#diff-b4e33ba8306827567807c9af84dde99d2b0b6e045ae904a4709cdb119388fdaeR3) [[2]](diffhunk://#diff-b4e33ba8306827567807c9af84dde99d2b0b6e045ae904a4709cdb119388fdaeL15-R16)

### New Route Files:

* [`apps/wjt/src/routes/index.ts`](diffhunk://#diff-d952be446968c84ce6575dd36cd560a8f30c2aa181b060653b11561475057be9R1-R8): Created a new router instance and integrated the versioned router (`v1Router`).
* [`apps/wjt/src/routes/v1.ts`](diffhunk://#diff-34f72280b7b564cea050b005adb3d99ba72915bf3413c4d8327553e1aea6a242R1-R18): Set up the `v1` router with a GET endpoint that returns the HTML response previously in `main.ts`.

### Dependency Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R8): Added `@koa/router` as a new dependency.

Closes #3 