### PR TITLE
chore: removes dry run from release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
 
-      - run: npx nx release --skip-publish --dry-run
+      - run: npx nx release --skip-publish


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change modifies the `npx nx release` command to remove the `--dry-run` flag, allowing the release to proceed without a dry run.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL61-R61): Modified the `npx nx release` command to remove the `--dry-run` flag.