### PR TITLE
fix: updates workflow trigger

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,7 +1,7 @@
 name: Check PR title
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -2,11 +2,6 @@ name: Check PR title
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - reopened
-      - edited
-      - synchronize
 
 jobs:
   lint:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,10 +1,12 @@
 name: Check PR title
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   actions: read
-  contents: read
   contents: write
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 
 permissions:
   actions: read
-  contents: read-write
+  contents: read
+  contents: write
 
 jobs:
   main:
@@ -55,10 +56,10 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - Configure Git
+      - name: Configure Git
         run: |
-            git config --global user.email ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
-            git config --global user.name ${{ secrets.GITHUB_ACTOR }}
+          git config --global user.email ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
+          git config --global user.name ${{ secrets.GITHUB_ACTOR }}
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to improve how pull request titles are checked. The most important change is the modification of the event type that triggers the workflow.

Changes to GitHub Actions workflow:

* [`.github/workflows/check-pr-title.yml`](diffhunk://#diff-bc9aba4a30fce974886cc629ca13a737e529d6ca6b38b3df12c6093200be0d50L4-R9): Changed the event type from `pull_request` to `pull_request_target` and specified the types of pull request events that should trigger the workflow, including `opened`, `reopened`, `edited`, and `synchronize`.