### PR TITLE
fix: adds secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
 
       - Configure Git
         run: |
-            git config --global user.email ${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com
-            git config --global user.name ${{ secrets.GITHUB_ACTOR }}
+            git config --global user.email ${{ secrets.USER_EMAIL }}
+            git config --global user.name ${{ secrets.USERNAME }}
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4


### PR DESCRIPTION
This pull request includes a change to the Git configuration in the CI workflow file to use different environment variables for the user email and name.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL60-R61): Updated the Git configuration to use `${{ secrets.USER_EMAIL }}` and `${{ secrets.USERNAME }}` instead of `${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com` and `${{ secrets.GITHUB_ACTOR }}`.