### PR TITLE
fix: adds github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,12 @@ jobs:
 
       - name: Configure Git
         run: |
-            git config --global user.email ${{ secrets.USER_EMAIL }}
-            git config --global user.name ${{ secrets.USERNAME }}
+          git config --global user.email ${{ secrets.USER_EMAIL }}
+          git config --global user.name ${{ secrets.USERNAME }}
 
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
 
       - run: npx nx release --skip-publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change adds the `GITHUB_TOKEN` environment variable to the `npx nx release --skip-publish` command.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR67-R68): Added `GITHUB_TOKEN` environment variable to the `npx nx release --skip-publish` command to ensure proper authentication.