### PR TITLE
chore: adds verbose flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,6 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - uses: nrwl/nx-set-shas@v4
 
-      - run: npx nx release --skip-publish
+      - run: npx nx release --skip-publish --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change adds the `--verbose` flag to the `npx nx release` command to provide more detailed output during the release process.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL66-R66): Added the `--verbose` flag to the `npx nx release` command to provide more detailed output.