### PR TITLE
fix: orchestrates build steps

### DIFF
--- a/.github/workflows/deploy-wjt.yml
+++ b/.github/workflows/deploy-wjt.yml
@@ -38,8 +38,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: 📦 Build wjt-service
+        run: npx nx build wjt
+
       - name: 🔨 Build WJT Docker Image
-        run: npx nx docker-build wjt
+        run: docker buildx build --platform linux/amd64 -f apps/wjt/Dockerfile -t wijohnst/wjt .
 
       - name: 📌 Push WJT Docker Image
         run: docker push wijohnst/wjt:latest

--- a/apps/wjt/README.md
+++ b/apps/wjt/README.md
@@ -2,4 +2,4 @@
 
 Koa service serving willjohnston.tech
 
-🐈💨💨💨
+🐈💨💨💨💨


### PR DESCRIPTION
This pull request includes changes to the build and deployment process for the `wjt-service` as well as a minor update to the `README.md` file. The most important changes are focused on improving the Docker build process and adding a new build step for the `wjt-service`.

Improvements to build and deployment process:

* [`.github/workflows/deploy-wjt.yml`](diffhunk://#diff-3b44da411da1263fdcaa0b495ba72c2834cd024f6ec3943f2fb0d53304a4aaadR41-R45): Added a new step to build the `wjt-service` using `npx nx build wjt` before building the Docker image.
* [`.github/workflows/deploy-wjt.yml`](diffhunk://#diff-3b44da411da1263fdcaa0b495ba72c2834cd024f6ec3943f2fb0d53304a4aaadR41-R45): Updated the Docker build command to use `docker buildx build` with the appropriate platform and Dockerfile.

Minor documentation update:

* [`apps/wjt/README.md`](diffhunk://#diff-f087fbbb11218618a269441fece8bd34c092723f5635cf6e73b7aa7544eb4ba4L5-R5): Added an extra emoji to the description of the Koa service.