### PR TITLE
fix(ci/cd): updates tag matcher

### DIFF
--- a/.github/workflows/deploy-wjt.yml
+++ b/.github/workflows/deploy-wjt.yml
@@ -1,12 +1,9 @@
-#26
-# TODO - nx docker-build wjt
-# TODO - push to Docker Hub
-# TODO - SSH into wjt-prod
-# TODO - Run `wjtr` alias
+name: 🚢 Deploy WJT
+
 on:
   push:
     tags:
-      - '**'
+      - v*
   workflow_dispatch:
 
 permissions:
@@ -15,7 +12,6 @@ permissions:
 
 jobs:
   deploy-wjt:
-    name: 🚢 Deploy WJT
     runs-on: ubuntu-latest
     steps:
       - name: 🛒 Checkout

--- a/apps/wjt/README.md
+++ b/apps/wjt/README.md
@@ -2,4 +2,4 @@
 
 Koa service serving willjohnston.tech
 
-🐈💨💨💨💨
+🐈💨💨💨💨💨


### PR DESCRIPTION
This pull request includes changes to the deployment workflow for the WJT project and a minor update to the README file. The most important changes are related to the deployment configuration in the `.github/workflows/deploy-wjt.yml` file.

Changes to deployment workflow:

* [`.github/workflows/deploy-wjt.yml`](diffhunk://#diff-3b44da411da1263fdcaa0b495ba72c2834cd024f6ec3943f2fb0d53304a4aaadL1-R6): Updated the workflow name to "🚢 Deploy WJT" and modified the tag pattern to trigger the workflow on tags starting with 'v'.
* [`.github/workflows/deploy-wjt.yml`](diffhunk://#diff-3b44da411da1263fdcaa0b495ba72c2834cd024f6ec3943f2fb0d53304a4aaadL18): Removed the duplicate job name "🚢 Deploy WJT" under the `jobs` section to avoid redundancy.

Minor update to documentation:

* [`apps/wjt/README.md`](diffhunk://#diff-f087fbbb11218618a269441fece8bd34c092723f5635cf6e73b7aa7544eb4ba4L5-R5): Added an extra cat emoji in the README file for stylistic purposes.