### PR TITLE
chore(wjt-service): adds error handling to enforce required frontmatter fields

### DIFF
--- a/apps/wjt/scripts/tests/static-posts.mocks.ts
+++ b/apps/wjt/scripts/tests/static-posts.mocks.ts
@@ -1,0 +1,28 @@
+export const mockPostContent = [
+  `---
+    title: Post 1
+    author: Some Author
+    slug: post-1
+    ---
+    # Post 1
+
+    This is the first post.
+    `,
+  `---
+    title: Post 2
+    author: Another Author
+    slug: post-2
+    ---
+    # Post 2
+
+    This is the second post.
+    `,
+  `---
+      title: Post 3
+      author: Yet Another Author 
+    ---
+    # Post 3
+
+    This is the third post.
+    `,
+];

--- a/apps/wjt/scripts/tests/static-posts.spec.ts
+++ b/apps/wjt/scripts/tests/static-posts.spec.ts
@@ -5,29 +5,10 @@ import {
   getRenderedPost,
 } from '../source/static-posts';
 
+import { mockPostContent } from './static-posts.mocks';
+
 import mockFs from 'mock-fs';
 import { readFileSync } from 'fs';
-
-const mockPostContent = [
-  `---
-    title: Post 1
-    author: Some Author
-    slug: post-1
-    ---
-    # Post 1
-
-    This is the first post.
-    `,
-  `---
-    title: Post 2
-    author: Another Author
-    slug: post-2
-    ---
-    # Post 2
-
-    This is the second post.
-    `,
-];
 
 describe('Static Posts', () => {
   beforeEach(() => {
@@ -84,6 +65,10 @@ describe('Static Posts', () => {
       expect(getFrontmatter).toBeDefined();
     });
 
+    test('should throw when frontmatter is missing', () => {
+      expect(() => getFrontmatter('')).toThrow();
+    });
+
     test('should return the frontmatter of a post', () => {
       const frontmatter = getFrontmatter(mockPostContent[0]);
       expect(frontmatter).toEqual({
@@ -91,6 +76,17 @@ describe('Static Posts', () => {
         author: 'Some Author',
         slug: 'post-1',
       });
+    });
+
+    test('frontmatter should not include `---` delimiters', () => {
+      const frontmatter = getFrontmatter(mockPostContent[0]);
+      expect(frontmatter).not.toContain('---');
+    });
+
+    test('should throw when default frontmatter is incomplete', () => {
+      const incompleteFrontmatter = mockPostContent[2];
+
+      expect(() => getFrontmatter(incompleteFrontmatter)).toThrow();
     });
   });
 

--- a/apps/wjt/src/posts/example-post-2.md
+++ b/apps/wjt/src/posts/example-post-2.md
@@ -1,7 +1,9 @@
 ---
 title: Example Post 2
 author: Will Johnston
+slug: example-post-2
 ---
+
 # Example Post 2
 
 This is my second example of a blog post. Its also written in markdown.

--- a/apps/wjt/src/posts/example-post.md
+++ b/apps/wjt/src/posts/example-post.md
@@ -1,6 +1,7 @@
 ---
 title: My Example Post
 author: Will Johnston
+slug: example-post
 ---
 
 # Example Post

--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,6 @@
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
   "neverConnectToCloud": true,
-  "nxCloudId": "67420ffe2ca4161ee6408a41",
   "targetDefaults": {
     "@nx/esbuild:esbuild": {
       "cache": true,


### PR DESCRIPTION
This pull request includes several changes to improve the handling and validation of frontmatter in static posts, as well as updates to test cases and mock data. The most important changes include adding validation for required frontmatter fields, updating mock data and test cases, and modifying existing posts to include a `slug` field.

### Frontmatter validation improvements:
* [`apps/wjt/scripts/source/static-posts.ts`](diffhunk://#diff-a1226925e9eaa402d60fe0f8cb5b9c4dc25ba7e6ceba72a21999e5507eeefd5cL85-R122): Added validation to ensure required frontmatter fields are present and updated the `getFrontmatter` function to throw an error if any required fields are missing.
* [`apps/wjt/scripts/static-posts.js`](diffhunk://#diff-ea67bc407775948999304c0c407fc6a5458cfe9f4f023d3a7889504ae1fb7ae3L87-R107): Added similar validation for required frontmatter fields in the `getFrontmatter` function.

### Test case updates:
* [`apps/wjt/scripts/tests/static-posts.spec.ts`](diffhunk://#diff-87cea237e0a6629f2a627448d4b31b596c54da9957d116279e73cf6285350915R68-R71): Updated test cases to include checks for missing frontmatter, delimiters, and incomplete default frontmatter. [[1]](diffhunk://#diff-87cea237e0a6629f2a627448d4b31b596c54da9957d116279e73cf6285350915R68-R71) [[2]](diffhunk://#diff-87cea237e0a6629f2a627448d4b31b596c54da9957d116279e73cf6285350915R80-R90)
* [`apps/wjt/scripts/tests/static-posts.spec.ts`](diffhunk://#diff-87cea237e0a6629f2a627448d4b31b596c54da9957d116279e73cf6285350915R8-L31): Imported `mockPostContent` from the new mock file to improve test data management.

### Mock data updates:
* [`apps/wjt/scripts/tests/static-posts.mocks.ts`](diffhunk://#diff-d4a384a6218a39a161debe1eecbb6622173d5e4c21b4f5cc6454027505180c3fR1-R28): Added `mockPostContent` to provide consistent mock data for tests.

### Post updates:
* [`apps/wjt/src/posts/example-post.md`](diffhunk://#diff-decdd99c79d620370a7e3ae2965bae687197dc6cedf00efd6d4afd879e4fa3b7R4): Added `slug` field to the frontmatter.
* [`apps/wjt/src/posts/example-post-2.md`](diffhunk://#diff-35ab1141be6cc9e7d74abb81510dfbd8297ab8c05938dd68b5a82cf315fc7d81R4-R6): Added `slug` field to the frontmatter.
## Associated Issue
Closes #48 