### PR TITLE
fix: updates build deps

### DIFF
--- a/apps/wjt/project.json
+++ b/apps/wjt/project.json
@@ -8,7 +8,7 @@
     "build": {
       "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
-      "dependsOn": ["bundle-css", "package-blog-static"],
+      "dependsOn": ["bundle-css", "generate-blog-posts"],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",

--- a/apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts
+++ b/apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts
@@ -1,4 +1,4 @@
-import MockFs from 'mock-fs';
+import mock from 'mock-fs';
 import {
   defaultFrontMatter,
   parseRawPost,
@@ -99,11 +99,15 @@ const targetPaths = Object.keys(postsMockFsEntry['src/posts']);
 describe('generate-blog-posts', () => {
   describe('getRawPostFileNames', () => {
     beforeEach(() => {
-      MockFs(postsMockFsEntry);
+      mock(postsMockFsEntry);
     });
 
     afterEach(() => {
-      MockFs.restore();
+      mock.restore();
+    });
+
+    afterAll(() => {
+      mock.restore();
     });
 
     test('should be defined', () => {
@@ -117,7 +121,7 @@ describe('generate-blog-posts', () => {
     });
 
     test('should not return any non-markdown files', () => {
-      MockFs({
+      mock({
         'src/posts': {
           ...postsMockFsEntry['src/posts'],
           'post-1.html': '',
@@ -131,11 +135,15 @@ describe('generate-blog-posts', () => {
 
   describe('getRawBlogPost', () => {
     beforeEach(() => {
-      MockFs(postsMockFsEntry);
+      mock(postsMockFsEntry);
     });
 
     afterEach(() => {
-      MockFs.restore();
+      mock.restore();
+    });
+
+    afterAll(() => {
+      mock.restore();
     });
 
     test('should be defined', () => {

--- a/apps/wjt/src/scripts/markdown-utils/markdown.utils.spec.ts
+++ b/apps/wjt/src/scripts/markdown-utils/markdown.utils.spec.ts
@@ -16,6 +16,14 @@ describe('markdown utils', () => {
       });
     });
 
+    afterEach(() => {
+      mock.restore();
+    });
+
+    afterAll(() => {
+      mock.restore();
+    });
+
     test('should be defined', () => {
       expect(updateMarkdown).toBeDefined();
     });

--- a/libs/images/src/lib/convert.spec.ts
+++ b/libs/images/src/lib/convert.spec.ts
@@ -34,6 +34,10 @@ describe('convert', () => {
       mock.restore();
     });
 
+    afterAll(() => {
+      mock.restore();
+    });
+
     test('should be defined', () => {
       expect(getBufferFromPath).toBeDefined();
     });


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and reliability of the test suite by standardizing the usage of the `mock-fs` library and updating dependencies.

Standardizing the usage of `mock-fs`:

* [`apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts`](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L1-R1): Replaced `MockFs` with `mock` and added `afterAll` hooks to ensure `mock.restore` is called after all tests. [[1]](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L1-R1) [[2]](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L102-R110) [[3]](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L120-R124) [[4]](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L134-R146)
* [`apps/wjt/src/scripts/markdown-utils/markdown.utils.spec.ts`](diffhunk://#diff-3c2e7ef434c31b70e4f242ca5f9adaabb12fd5f13ace7ffae1fbca5f333ad041R19-R26): Added `afterEach` and `afterAll` hooks to call `mock.restore` after tests.
* [`libs/images/src/lib/convert.spec.ts`](diffhunk://#diff-918d375ccf22665fb7af54a355e7c523b2130f6f21c3587b2596fafc44b4cb5aR37-R40): Added `afterAll` hook to call `mock.restore` after all tests.

Updating dependencies:

* [`apps/wjt/project.json`](diffhunk://#diff-88959aedfee85751226ddf0c37f88c21ff47e0096df9fce6d0dfceef129eaeb0L11-R11): Changed the dependency from `package-blog-static` to `generate-blog-posts` in the `dependsOn` array.