### PR TITLE
chore(wjt-service): wjt-61 - adds custom html renderer for blog posts

### DIFF
--- a/apps/wjt/src/scripts/blog-post/blog-post.mocks.ts
+++ b/apps/wjt/src/scripts/blog-post/blog-post.mocks.ts
@@ -1,4 +1,4 @@
-import { DefaultFrontMatter } from './blog-post';
+import { RequiredFrontMatter } from './blog-post';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { cwd } from 'process';
@@ -54,7 +54,7 @@ export const getMockFrontmatter = (
   author: string,
   slug: string,
   description: string
-): DefaultFrontMatter => ({
+): RequiredFrontMatter => ({
   title,
   author,
   slug,

--- a/apps/wjt/src/scripts/blog-post/blog-post.ts
+++ b/apps/wjt/src/scripts/blog-post/blog-post.ts
@@ -1,26 +1,38 @@
 import { Node } from 'commonmark';
 import {
-  parseRawPost,
+  parseRawMarkdownPost,
   renderPost,
   getImageNodes,
   generatePostImage,
-  updateImageSources,
+  _updateImageSources,
 } from './blog-post.utils';
 
-export type DefaultFrontMatter = {
+/**
+ * Represents the required front matter for a blog post
+ */
+export type RequiredFrontMatter = {
   title: string;
   author: string;
   slug: string;
   description: string;
 };
 
-export type RawPost = string;
+/**
+ * A string representation of a raw markdown document
+ */
+export type RawMarkdownPost = string;
 
+/**
+ * A parsed markdown document
+ */
 export type Post = {
-  frontMatter: DefaultFrontMatter;
+  frontMatter: RequiredFrontMatter;
   content: string;
 };
 
+/**
+ * Represents an image in a blog post
+ */
 export type PostImage = {
   originalSrc: string;
   altText: string;
@@ -29,13 +41,19 @@ export type PostImage = {
   cdnEndpoint?: string;
 };
 
+/**
+ * Represents a mapping of image source updates
+ */
 export type ImageUpdateMap = {
   originalSrc: string;
   newSrc: string;
 };
 
+/**
+ * Represents a blog post in @wjt/service
+ */
 export interface IBlogPost {
-  rawPost: RawPost;
+  rawPost: RawMarkdownPost;
   parsedPost: Post;
   postMarkup: string;
   postImages?: PostImage[];
@@ -50,8 +68,8 @@ export class BlogPost implements IBlogPost {
 
   private _imageNodes?: Node[] | undefined;
 
-  constructor(public rawPost: RawPost) {
-    this.parsedPost = parseRawPost(rawPost);
+  constructor(public rawPost: RawMarkdownPost) {
+    this.parsedPost = parseRawMarkdownPost(rawPost);
     this.postMarkup = renderPost(this.parsedPost);
     this._imageNodes = getImageNodes(this.parsedPost.content);
     this.initPostImages();
@@ -64,7 +82,7 @@ export class BlogPost implements IBlogPost {
   }
 
   public updateImageSources(imageUpdateMap: ImageUpdateMap[]): void {
-    const updatedPost = updateImageSources(imageUpdateMap, this.parsedPost);
+    const updatedPost = _updateImageSources(imageUpdateMap, this.parsedPost);
 
     this.parsedPost = updatedPost;
     this.postMarkup = renderPost(updatedPost);

--- a/apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts
+++ b/apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts
@@ -1,7 +1,7 @@
 import mock from 'mock-fs';
 import {
   defaultFrontMatter,
-  parseRawPost,
+  parseRawMarkdownPost,
   getFrontmatter,
   renderPost,
   getRawBlogPost,
@@ -22,11 +22,11 @@ describe('blog-post.utils', () => {
     expect(defaultFrontMatter).toBeDefined();
   });
 
-  describe('parseRawPost - util', () => {
-    test('should be defined', () => expect(parseRawPost).toBeDefined());
+  describe('parseRawMarkdownPost - util', () => {
+    test('should be defined', () => expect(parseRawMarkdownPost).toBeDefined());
 
     test('should return the correct post object', () => {
-      const post = parseRawPost(rawPostMocks[0]);
+      const post = parseRawMarkdownPost(rawPostMocks[0]);
       const frontMatter = getMockFrontmatter(
         'Post 1',
         'Some Author',
@@ -190,7 +190,7 @@ describe('generate-blog-posts', () => {
     });
 
     test('should update the image sources in a post', () => {
-      const post = parseRawPost(rawPostMocks[0]);
+      const post = parseRawMarkdownPost(rawPostMocks[0]);
       const imageUpdates: ImageUpdateMap[] = [
         {
           originalSrc: './path/to/image-1.jpg',

--- a/apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts
+++ b/apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts
@@ -6,7 +6,7 @@ import {
   renderPost,
   getRawBlogPost,
   getRawPostFileNames,
-  updateImageSources,
+  _updateImageSources,
 } from './blog-post.utils';
 
 import {
@@ -186,7 +186,7 @@ describe('generate-blog-posts', () => {
 
   describe('updateImageSources', () => {
     test('should be defined', () => {
-      expect(updateImageSources).toBeDefined();
+      expect(_updateImageSources).toBeDefined();
     });
 
     test('should update the image sources in a post', () => {
@@ -202,7 +202,7 @@ describe('generate-blog-posts', () => {
         'This is the first post.',
         `![Image 1](${imageUpdates[0].newSrc})`,
       ]);
-      const updatedPost = updateImageSources(imageUpdates, post);
+      const updatedPost = _updateImageSources(imageUpdates, post);
 
       expect(updatedPost.content).toEqual(expectedContent);
       expect(updatedPost.content).toMatchSnapshot();

--- a/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.spec.ts
+++ b/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.spec.ts
@@ -34,7 +34,7 @@ describe('BlogPostRenderer', () => {
   });
 
   test('should not render a picture tag for unsafe protocols', () => {
-    let sut = new BlogPostRenderer({
+    const sut = new BlogPostRenderer({
       safe: true,
     });
     const content = `# Hello World\n\n![alt text](javascript:alert('hello'))`;

--- a/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.spec.ts
+++ b/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.spec.ts
@@ -1,0 +1,51 @@
+import { HtmlRenderer, Parser } from 'commonmark';
+import { BlogPostRenderer } from './BlogPostRenderer';
+
+const normalizeWhitespace = (str: string): string => {
+  return str.replace(/\s+/g, ' ').trim();
+};
+
+describe('BlogPostRenderer', () => {
+  test('should be defined', () => {
+    expect(BlogPostRenderer).toBeDefined();
+  });
+
+  let sut: BlogPostRenderer;
+
+  beforeEach(() => {
+    sut = new BlogPostRenderer();
+  });
+
+  test('should be an instance of HtmlRenderer', () => {
+    expect(sut).toBeInstanceOf(HtmlRenderer);
+  });
+
+  test('should have an image method that renders a picture tag', () => {
+    const content = `# Hello World\n\n![alt text](https://example.com/image.jpg)`;
+
+    const parsed = new Parser().parse(content);
+    const rendered = sut.render(parsed);
+
+    expect(normalizeWhitespace(rendered)).toBe(
+      normalizeWhitespace(
+        '<h1>Hello World</h1>\n<p><picture> <source srcset="https://example.com/image.webp" type="image/webp"> <img src="https://example.com/image.jpg" alt="alt text" /></picture></p>\n'
+      )
+    );
+  });
+
+  test('should not render a picture tag for unsafe protocols', () => {
+    let sut = new BlogPostRenderer({
+      safe: true,
+    });
+    const content = `# Hello World\n\n![alt text](javascript:alert('hello'))`;
+
+    const parsed = new Parser().parse(content);
+    const rendered = sut.render(parsed);
+
+    expect(normalizeWhitespace(rendered)).toBe(
+      normalizeWhitespace(
+        '<h1>Hello World</h1>\n<p><picture><img src="" alt="alt text" /></picture></p>\n'
+      )
+    );
+  });
+});

--- a/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.ts
+++ b/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.ts
@@ -1,9 +1,9 @@
 import { HtmlRenderer, Node, HtmlRenderingOptions } from 'commonmark';
 
-var reUnsafeProtocol = /^javascript:|vbscript:|file:|data:/i;
-var reSafeDataProtocol = /^data:image\/(?:png|gif|jpeg|webp)/i;
+const reUnsafeProtocol = /^javascript:|vbscript:|file:|data:/i;
+const reSafeDataProtocol = /^data:image\/(?:png|gif|jpeg|webp)/i;
 
-var potentiallyUnsafe = function (url) {
+const potentiallyUnsafe = function (url) {
   return reUnsafeProtocol.test(url) && !reSafeDataProtocol.test(url);
 };
 export class BlogPostRenderer extends HtmlRenderer {

--- a/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.ts
+++ b/apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.ts
@@ -1,0 +1,48 @@
+import { HtmlRenderer, Node, HtmlRenderingOptions } from 'commonmark';
+
+var reUnsafeProtocol = /^javascript:|vbscript:|file:|data:/i;
+var reSafeDataProtocol = /^data:image\/(?:png|gif|jpeg|webp)/i;
+
+var potentiallyUnsafe = function (url) {
+  return reUnsafeProtocol.test(url) && !reSafeDataProtocol.test(url);
+};
+export class BlogPostRenderer extends HtmlRenderer {
+  options: HtmlRenderingOptions;
+  constructor(options: HtmlRenderingOptions = {}) {
+    super();
+    this.options = options;
+  }
+
+  image!: (node: Node, entering: boolean) => void;
+}
+
+BlogPostRenderer.prototype.image = function (node, entering) {
+  if (entering) {
+    if (this.disableTags === 0) {
+      if (this.options.safe && potentiallyUnsafe(node.destination)) {
+        this.lit('<picture><img src="" alt="');
+      } else {
+        // Generate a WebP alternative by replacing the extension
+        const webpSrc = node.destination.replace(/\.\w+$/, '.webp');
+        this.lit(
+          `<picture>
+            ${getSource(webpSrc)}
+          <img src="${this.esc(node.destination)}" alt="`
+        );
+      }
+    }
+    this.disableTags += 1;
+  } else {
+    this.disableTags -= 1;
+    if (this.disableTags === 0) {
+      if (node.title) {
+        this.lit(`" title="${this.esc(node.title)}`);
+      }
+      this.lit('" /></picture>');
+    }
+  }
+};
+
+export const getSource = (escapedFileName: string): string => {
+  return `<source srcset="${escapedFileName}" type="image/webp">`;
+};

--- a/apps/wjt/src/scripts/markdown-utils/markdown.utils.ts
+++ b/apps/wjt/src/scripts/markdown-utils/markdown.utils.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from 'fs';
 import {
   Post,
   ImageUpdateMap,
-  updateImageSources,
+  _updateImageSources,
   postsPath,
 } from '../blog-post';
 import { join } from 'path';
@@ -10,10 +10,10 @@ import { join } from 'path';
 export const updateMarkdown = (
   targetFileName: string,
   parsedPost: Post,
-  imageUpdateMap: ImageUpdateMap[]
+  imageUpdateMapArr: ImageUpdateMap[]
 ): string => {
   const frontmatter = generateFrontmatterString(parsedPost.frontMatter);
-  const updatedPost = updateImageSources(imageUpdateMap, parsedPost);
+  const updatedPost = _updateImageSources(imageUpdateMapArr, parsedPost);
   const finalPost = `${frontmatter}\n\n${updatedPost.content}`;
   writeFileSync(join(postsPath, targetFileName), finalPost);
   return finalPost;

--- a/apps/wjt/src/scripts/utils/utils.spec.ts
+++ b/apps/wjt/src/scripts/utils/utils.spec.ts
@@ -5,8 +5,6 @@ import fs from 'fs';
 import { join } from 'path';
 import { cwd } from 'process';
 
-import { getRawBlogPost } from '../blog-post';
-
 describe('utils', () => {
   describe('processPosts', () => {
     test('should be defined', () => {

--- a/apps/wjt/src/scripts/utils/utils.spec.ts
+++ b/apps/wjt/src/scripts/utils/utils.spec.ts
@@ -1,9 +1,11 @@
 import mock from 'mock-fs';
 import * as utils from './utils';
-import { mockFileSystem, BlogPost, PostImage } from '../blog-post';
+import { mockFileSystem, BlogPost } from '../blog-post';
 import fs from 'fs';
 import { join } from 'path';
 import { cwd } from 'process';
+
+import { getRawBlogPost } from '../blog-post';
 
 describe('utils', () => {
   describe('processPosts', () => {
@@ -38,7 +40,6 @@ describe('utils', () => {
 
       expect(utils.handleImageConversion).toHaveBeenCalledWith(
         'example-post.md',
-        expect.any(Array<PostImage>),
         expect.any(BlogPost)
       );
     });

--- a/apps/wjt/src/scripts/utils/utils.ts
+++ b/apps/wjt/src/scripts/utils/utils.ts
@@ -10,7 +10,6 @@ import {
   getRawBlogPost,
   getRawPostFileNames,
   postsPath,
-  PostImage,
   ImageUpdateMap,
 } from '../blog-post';
 import {
@@ -48,7 +47,7 @@ export const processPosts = async (rawPostFileNames: string[]) => {
       blogPost.parsedPost.frontMatter.slug + '.html'
     );
 
-    await handleImageConversion(rawPostFileName, blogPost.postImages, blogPost);
+    await handleImageConversion(rawPostFileName, blogPost);
 
     writeFileSync(targetPath, blogPost.postMarkup);
   }
@@ -62,12 +61,11 @@ export const processPosts = async (rawPostFileNames: string[]) => {
  */
 export const handleImageConversion = async (
   rawPostFileName: string,
-  postImages: PostImage[],
   blogPost: BlogPost
 ) => {
   const imageUpdates: ImageUpdateMap[] = [];
 
-  for (const postImage of postImages) {
+  for (const postImage of blogPost.postImages) {
     if (isCdnImage(postImage.originalSrc, DEFAULT_CDN_MATCHER)) {
       console.log('✅ Image is already on CDN. Skipping conversion...\n');
       continue;
@@ -86,7 +84,9 @@ export const handleImageConversion = async (
       const webPBuffer = await convertBufferToWebp(
         await getBufferFromPath(targetPath)
       );
+
       console.log(`🆙 Uploading ${targetImageName} to CDN...\n`);
+
       const { cdnEndpointUrl } = await wjtSpacesClient.putWebpObject({
         Body: webPBuffer,
         Key: targetImageName,


### PR DESCRIPTION
This pull request includes several changes aimed at improving the blog post handling and rendering in the application. The changes mainly focus on renaming types for clarity, updating method names, and adding new functionality for rendering images in markdown posts.

### Type and Method Renaming:

* [`apps/wjt/src/scripts/blog-post/blog-post.ts`](diffhunk://#diff-b4efa07a0bfedc8ea52740c7bfd22a08280fa4f0aceb7d1b01ef85c193067029L3-R35): Renamed `DefaultFrontMatter` to `RequiredFrontMatter` and `RawPost` to `RawMarkdownPost` for better clarity.
* [`apps/wjt/src/scripts/blog-post/blog-post.utils.ts`](diffhunk://#diff-a4bee1dffbc5d22ac573a2f7da645382d9a407f72066668f892d30fb45de2c2aL47-R59): Updated method names from `parseRawPost` to `parseRawMarkdownPost` and `updateImageSources` to `_updateImageSources`. [[1]](diffhunk://#diff-a4bee1dffbc5d22ac573a2f7da645382d9a407f72066668f892d30fb45de2c2aL47-R59) [[2]](diffhunk://#diff-a4bee1dffbc5d22ac573a2f7da645382d9a407f72066668f892d30fb45de2c2aL227-R255)

### Updates in Blog Post Mocking:

* [`apps/wjt/src/scripts/blog-post/blog-post.mocks.ts`](diffhunk://#diff-df8e484fb7349d001a05a4fa538ef27c50f99125f625708dc08f203aa6033247L57-R57): Changed type from `DefaultFrontMatter` to `RequiredFrontMatter` in the `getMockFrontmatter` function.

### Test Updates:

* [`apps/wjt/src/scripts/blog-post/blog-post.utils.spec.ts`](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L25-R29): Updated tests to reflect the renaming of `parseRawPost` to `parseRawMarkdownPost` and `updateImageSources` to `_updateImageSources`. [[1]](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L25-R29) [[2]](diffhunk://#diff-318b61989d5eb33e1befd25d53a90a49e1e34bc908abe300f1d4c98789c813e3L189-R193)

### New Blog Post Renderer:

* [`apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.ts`](diffhunk://#diff-66a44604b4893c1e5820ced3663be58414400a6f63a6522783914d5ff60c7549R1-R48): Added a new `BlogPostRenderer` class that extends `HtmlRenderer` to render images with a `picture` tag, including a WebP alternative.
* [`apps/wjt/src/scripts/markdown-utils/BlogPostRenderer.spec.ts`](diffhunk://#diff-f300714bcac69d1ee362e1b4298b080ae6aa763a15392fd097244de58c25c612R1-R51): Added tests for the new `BlogPostRenderer` to ensure it renders images correctly and handles unsafe protocols.

### Utility Function Updates:

* [`apps/wjt/src/scripts/utils/utils.ts`](diffhunk://#diff-731ba85d6eb6338bfe03769c2960315fd0a7371c7d17d7f17dc23b54db7a27faL65-R68): Simplified the `handleImageConversion` function by removing the `postImages` parameter and using `blogPost.postImages` directly.