### PR TITLE
fix(wjt-service): updates CDN matcher

### DIFF
--- a/apps/wjt/build/generate-blog-posts.cjs
+++ b/apps/wjt/build/generate-blog-posts.cjs
@@ -50,7 +50,7 @@ var WJT_SPACES_BUCKET_ID = `wjt`;
 var WJT_SPACES_CDN_ENDPOINT = `https://wjt.sfo2.cdn.digitaloceanspaces.com`;
 var WJT_SPACES_ENDPOINT = `https://sfo2.digitaloceanspaces.com`;
 var WJT_SPACES_REGION = `sfo2`;
-var DEFAULT_CDN_MATCHER = /https:\/\/wjt\.sfo2\.cdn\.digitaloceanspaces\.com\/.*.webp/;
+var DEFAULT_CDN_MATCHER = /https:\/\/wjt\.sfo2\.cdn\.digitaloceanspaces\.com\/.*/;
 var wjtSpacesClientDefaultConfig = {
   region: WJT_SPACES_REGION,
   endpoint: WJT_SPACES_ENDPOINT,

--- a/apps/wjt/build/package.json
+++ b/apps/wjt/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wjt/service",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "imports": {
     "#package": "./package.json"
   }

--- a/apps/wjt/src/scripts/utils/utils.ts
+++ b/apps/wjt/src/scripts/utils/utils.ts
@@ -1,10 +1,6 @@
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import {
-  isCdnImage,
-  getBufferFromPath,
-  convertBufferToWebp,
-} from '@wjt/images';
+import { isCdnImage, getBufferFromPath } from '@wjt/images';
 import {
   BlogPost,
   getRawBlogPost,

--- a/apps/wjt/src/scripts/wjt-spaces-client/wjt-spaces-client.ts
+++ b/apps/wjt/src/scripts/wjt-spaces-client/wjt-spaces-client.ts
@@ -14,7 +14,7 @@ export const WJT_SPACES_CDN_ENDPOINT = `https://wjt.sfo2.cdn.digitaloceanspaces.
 export const WJT_SPACES_ENDPOINT = `https://sfo2.digitaloceanspaces.com`;
 export const WJT_SPACES_REGION = `sfo2`;
 export const DEFAULT_CDN_MATCHER =
-  /https:\/\/wjt\.sfo2\.cdn\.digitaloceanspaces\.com\/.*.webp/;
+  /https:\/\/wjt\.sfo2\.cdn\.digitaloceanspaces\.com\/.*/;
 
 export interface IWjtSpacesClient {
   s3Client: S3Client;

--- a/libs/images/src/lib/utils.spec.ts
+++ b/libs/images/src/lib/utils.spec.ts
@@ -41,8 +41,7 @@ describe('images', () => {
     test('should return true for a CDN image', () => {
       const path =
         'https://wjt.sfo2.cdn.digitaloceanspaces.com/sample_image.webp';
-      const matcher =
-        /https:\/\/wjt\.sfo2\.cdn\.digitaloceanspaces\.com\/.*\.webp/;
+      const matcher = /https:\/\/wjt\.sfo2\.cdn\.digitaloceanspaces\.com\/.*/;
 
       expect(isCdnImage(path, matcher)).toBe(true);
     });


### PR DESCRIPTION
This pull request includes several changes across different files to update the CDN matcher and package version, as well as to remove an unused import. The most important changes are as follows:

### CDN Matcher Update:
* [`apps/wjt/build/generate-blog-posts.cjs`](diffhunk://#diff-a4c4237febf6240df1bc36da159d88e3127386ef0576a53415e9871afbc35cf7L53-R53): Updated `DEFAULT_CDN_MATCHER` to match any file type instead of only `.webp` files.
* [`apps/wjt/src/scripts/wjt-spaces-client/wjt-spaces-client.ts`](diffhunk://#diff-bd667b60614e4c639da7cd2b5efab76372f9c097cf38b09fb8ff33230143aa92L17-R17): Updated `DEFAULT_CDN_MATCHER` to match any file type instead of only `.webp` files.
* [`libs/images/src/lib/utils.spec.ts`](diffhunk://#diff-faf9e81b9b2e75d0188eadaed85563ccd9efbef28d0fa7e1be5bf829a8c30aadL44-R44): Updated the test case to use the new `DEFAULT_CDN_MATCHER` that matches any file type.

### Package Version Update:
* [`apps/wjt/build/package.json`](diffhunk://#diff-ebe8526c03c7b53f579a66349087b6e2c82c86b06f00cd0dd7c7ae1a4a85dfd1L3-R3): Updated the package version from `0.11.0` to `0.12.0`.

### Import Cleanup:
* [`apps/wjt/src/scripts/utils/utils.ts`](diffhunk://#diff-731ba85d6eb6338bfe03769c2960315fd0a7371c7d17d7f17dc23b54db7a27faL3-R3): Removed the unused import `convertBufferToWebp` from the `@wjt/images` package.