### PR TITLE
feat(wjt-service): wjt-61 - implements blog image 

### DIFF
--- a/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
@@ -99,6 +99,16 @@ describe('BlogImage', () => {
     });
   });
 
+  describe('imageName', () => {
+    test('should be defined', () => {
+      expect(sut.imageName).toBeDefined();
+    });
+
+    test('should return the image name', () => {
+      expect(sut.imageName).toEqual('image');
+    });
+  });
+
   describe('sourceSet', () => {
     test('should be defined', () => {
       expect(sut.sourceSet).toBeDefined();
@@ -123,7 +133,7 @@ describe('BlogImage', () => {
         const srcSet = generateSrcSet(
           responsiveImageWidths,
           WJT_SPACES_CDN_ENDPOINT,
-          'image.jpg'
+          'image'
         );
 
         expect(srcSet).toEqual([

--- a/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
@@ -1,24 +1,136 @@
 import mock from 'mock-fs';
-import { BlogImage } from './blog-image';
+import { BlogImage, generateSrcSet } from './blog-image';
+import {
+  parseMarkdownString,
+  getImageNodes,
+} from '../blog-post/image-naming-spec/test-utils';
+import {
+  DEFAULT_CDN_MATCHER,
+  WJT_SPACES_CDN_ENDPOINT,
+} from '../wjt-spaces-client';
+
+jest.mock('console');
 
 describe('BlogImage', () => {
   test('should be defined', () => {
     expect(BlogImage).toBeDefined();
   });
 
-  describe('imageBuffer', () => {
-    beforeEach(() => {
-      mock({
-        'path/to/image.jpg': Buffer.from('image data!'),
-      });
+  let sut: BlogImage;
+
+  beforeEach(() => {
+    const parentNode = parseMarkdownString('![alt-text$200x200](image.jpg)');
+    const [node] = getImageNodes(parentNode);
+
+    mock({
+      'path/to/image.jpg': Buffer.from('image data'),
     });
 
-    test('should return a Buffer', async () => {
-      const blogImage = new BlogImage('path/to/image.jpg');
-      await blogImage.generateImageBuffer();
+    sut = new BlogImage(
+      'path/to/image.jpg',
+      node,
+      DEFAULT_CDN_MATCHER,
+      WJT_SPACES_CDN_ENDPOINT,
+      [200]
+    );
+  });
 
-      expect(blogImage.imageBuffer).toBeInstanceOf(Buffer);
-      expect(blogImage.imageBuffer).toMatchSnapshot();
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('imageBuffer', () => {
+    beforeEach(() => {});
+
+    test('should return a Buffer', async () => {
+      await sut.generateImageBuffer();
+
+      expect(sut.imageBuffer).toBeInstanceOf(Buffer);
+    });
+  });
+
+  describe('isCDNImage', () => {
+    test('should be defined', () => {
+      expect(sut.isCDNPath).toBeDefined();
+    });
+
+    test('should return false for a local image path', () => {
+      expect(sut.isCDNPath).toBe(false);
+    });
+
+    test('should return true for a CDN image path', () => {
+      const cdnMatcher = /cdn\.example\.com/;
+      const cdnNode = parseMarkdownString(
+        '![alt-text$200x200](https://cdn.example.com/image.jpg)'
+      );
+      const [cdnImageNode] = getImageNodes(cdnNode);
+
+      const cdnImage = new BlogImage(
+        'https://cdn.example.com/image.jpg',
+        cdnImageNode,
+        cdnMatcher
+      );
+
+      expect(cdnImage.isCDNPath).toBe(true);
+    });
+  });
+
+  describe('imageMetaData', () => {
+    test('should be defined', () => {
+      expect(sut.imageMetaData).toBeDefined();
+    });
+
+    test('should return the image metadata', () => {
+      expect(sut.imageMetaData).toEqual({
+        altText: 'alt-text',
+        width: 200,
+        height: 200,
+      });
+    });
+  });
+
+  describe('imageSrc', () => {
+    test('should be defined', () => {
+      expect(sut.imageSrc).toBeDefined();
+    });
+
+    test('should return the image src', () => {
+      expect(sut.imageSrc).toEqual('image.jpg');
+    });
+  });
+
+  describe('sourceSet', () => {
+    test('should be defined', () => {
+      expect(sut.sourceSet).toBeDefined();
+    });
+
+    test('should return the correct sourceSet array', () => {
+      expect(sut.sourceSet).toEqual([
+        `${WJT_SPACES_CDN_ENDPOINT}/image-200w.webp 200w`,
+      ]);
+    });
+  });
+
+  describe('utils', () => {
+    describe('generateSrcSet', () => {
+      test('should be defined', () => {
+        expect(generateSrcSet).toBeDefined();
+      });
+
+      test('should return the correct src set array', () => {
+        const responsiveImageWidths = [200, 400];
+
+        const srcSet = generateSrcSet(
+          responsiveImageWidths,
+          WJT_SPACES_CDN_ENDPOINT,
+          'image.jpg'
+        );
+
+        expect(srcSet).toEqual([
+          `${WJT_SPACES_CDN_ENDPOINT}/image-200w.webp 200w`,
+          `${WJT_SPACES_CDN_ENDPOINT}/image-400w.webp 400w`,
+        ]);
+      });
     });
   });
 });

--- a/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
@@ -38,8 +38,6 @@ describe('BlogImage', () => {
   });
 
   describe('imageBuffer', () => {
-    beforeEach(() => {});
-
     test('should return a Buffer', async () => {
       await sut.generateImageBuffer();
 

--- a/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
@@ -1,0 +1,24 @@
+import mock from 'mock-fs';
+import { BlogImage } from './blog-image';
+
+describe('BlogImage', () => {
+  test('should be defined', () => {
+    expect(BlogImage).toBeDefined();
+  });
+
+  describe('imageBuffer', () => {
+    beforeEach(() => {
+      mock({
+        'path/to/image.jpg': Buffer.from('image data!'),
+      });
+    });
+
+    test('should return a Buffer', async () => {
+      const blogImage = new BlogImage('path/to/image.jpg');
+      await blogImage.generateImageBuffer();
+
+      expect(blogImage.imageBuffer).toBeInstanceOf(Buffer);
+      expect(blogImage.imageBuffer).toMatchSnapshot();
+    });
+  });
+});

--- a/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.spec.ts
@@ -9,8 +9,6 @@ import {
   WJT_SPACES_CDN_ENDPOINT,
 } from '../wjt-spaces-client';
 
-jest.mock('console');
-
 describe('BlogImage', () => {
   test('should be defined', () => {
     expect(BlogImage).toBeDefined();

--- a/apps/wjt/src/scripts/blog-image/blog-image.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.ts
@@ -1,0 +1,27 @@
+import { getBufferFromPath } from '@wjt/images';
+
+export class BlogImage {
+  private fallbackSrcPath: string;
+  public _imageBuffer: Buffer;
+
+  constructor(srcPath: string) {
+    this.fallbackSrcPath = srcPath;
+  }
+
+  async generateImageBuffer(): Promise<void> {
+    try {
+      this._imageBuffer = await getBufferFromPath(this.fallbackSrcPath);
+    } catch (e) {
+      console.error('BlogImage Error: error generating image buffer', e);
+    }
+  }
+
+  get imageBuffer(): Buffer {
+    if (!this._imageBuffer) {
+      console.error('BlogImage Error: image buffer not generated');
+      return;
+    }
+
+    return this._imageBuffer;
+  }
+}

--- a/apps/wjt/src/scripts/blog-image/blog-image.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.ts
@@ -1,11 +1,47 @@
 import { getBufferFromPath } from '@wjt/images';
+import { Node } from 'commonmark';
+import { isCdnImage as _isCDNImage } from '@wjt/images';
+import {
+  DEFAULT_CDN_MATCHER,
+  WJT_SPACES_CDN_ENDPOINT,
+} from '../wjt-spaces-client';
+import {
+  ImageMetaData,
+  parseCommonmarkImage,
+  parseMetaText,
+} from '../blog-post';
+
+type Width = number;
+type ResponsiveImageWidths = Array<Width>;
+
+const DEFAULT_SOURCE_SET: ResponsiveImageWidths = [320, 480, 800, 1600];
 
 export class BlogImage {
-  private fallbackSrcPath: string;
-  public _imageBuffer: Buffer;
+  private readonly fallbackSrcPath: string;
+  private readonly _isCDNPath: boolean;
+  private readonly CDN_PATH: string;
+  private readonly responsiveImageWidths: ResponsiveImageWidths;
+  private _imageMetaData: ImageMetaData;
+  private _imageSrc: string;
 
-  constructor(srcPath: string) {
+  public _imageBuffer: Buffer;
+  public self: Node;
+  public sourceSet: string[];
+
+  constructor(
+    srcPath: string,
+    node: Node,
+    CDN_MATCHER = DEFAULT_CDN_MATCHER,
+    TARGET_CDN_PATH = WJT_SPACES_CDN_ENDPOINT,
+    responsiveImageWidths: ResponsiveImageWidths = DEFAULT_SOURCE_SET
+  ) {
+    this.self = node;
     this.fallbackSrcPath = srcPath;
+    this._isCDNPath = _isCDNImage(srcPath, CDN_MATCHER);
+    this.CDN_PATH = TARGET_CDN_PATH;
+    this.responsiveImageWidths = responsiveImageWidths;
+    this.initImageData();
+    this.sourceSet = this.initSourceSet();
   }
 
   async generateImageBuffer(): Promise<void> {
@@ -16,12 +52,56 @@ export class BlogImage {
     }
   }
 
+  private initImageData(): void {
+    try {
+      const { alt, src } = parseCommonmarkImage(this.self);
+      this._imageMetaData = parseMetaText(alt);
+      this._imageSrc = src;
+    } catch (error) {
+      console.error('BlogImage Error: error parsing image metadata', error);
+    }
+  }
+
+  private initSourceSet(): string[] {
+    return generateSrcSet(
+      this.responsiveImageWidths,
+      this.CDN_PATH,
+      this._imageSrc
+    );
+  }
+
   get imageBuffer(): Buffer {
     if (!this._imageBuffer) {
-      console.error('BlogImage Error: image buffer not generated');
+      console.error(
+        'BlogImage Error: image buffer not generated. Run BlogImage.generateImageBuffer()'
+      );
       return;
     }
 
     return this._imageBuffer;
   }
+
+  get isCDNPath(): boolean {
+    return this._isCDNPath;
+  }
+
+  get imageMetaData(): ImageMetaData {
+    return this._imageMetaData;
+  }
+
+  get imageSrc(): string {
+    return this._imageSrc;
+  }
 }
+
+// UTILS
+export const generateSrcSet = (
+  responsiveImageWidths: ResponsiveImageWidths,
+  cdnPath: string,
+  imageSrc: string
+): string[] => {
+  const [imageName] = imageSrc.split('.');
+  return responsiveImageWidths.map(
+    (width) => `${cdnPath}/${imageName}-${width}w.webp ${width}w`
+  );
+};

--- a/apps/wjt/src/scripts/blog-image/blog-image.ts
+++ b/apps/wjt/src/scripts/blog-image/blog-image.ts
@@ -21,8 +21,10 @@ export class BlogImage {
   private readonly _isCDNPath: boolean;
   private readonly CDN_PATH: string;
   private readonly responsiveImageWidths: ResponsiveImageWidths;
-  private _imageMetaData: ImageMetaData;
+  private readonly _imageName: string;
+
   private _imageSrc: string;
+  private _imageMetaData: ImageMetaData;
 
   public _imageBuffer: Buffer;
   public self: Node;
@@ -66,7 +68,7 @@ export class BlogImage {
     return generateSrcSet(
       this.responsiveImageWidths,
       this.CDN_PATH,
-      this._imageSrc
+      this.imageName
     );
   }
 
@@ -92,15 +94,19 @@ export class BlogImage {
   get imageSrc(): string {
     return this._imageSrc;
   }
+
+  get imageName(): string {
+    const [imageName] = this._imageSrc.split('.');
+    return imageName;
+  }
 }
 
 // UTILS
 export const generateSrcSet = (
   responsiveImageWidths: ResponsiveImageWidths,
   cdnPath: string,
-  imageSrc: string
+  imageName: string
 ): string[] => {
-  const [imageName] = imageSrc.split('.');
   return responsiveImageWidths.map(
     (width) => `${cdnPath}/${imageName}-${width}w.webp ${width}w`
   );


### PR DESCRIPTION
This pull request introduces a new `BlogImage` class and associated tests to handle image processing for blog posts. The changes include the implementation of the `BlogImage` class, utility functions, and comprehensive unit tests to ensure the functionality works as expected.

### Implementation of `BlogImage` class and utilities:

* [`apps/wjt/src/scripts/blog-image/blog-image.ts`](diffhunk://#diff-849f54b6048af5e65923bab140a9b25be7bb1742dc351a25179c4153d3dc80fbR1-R107): Added the `BlogImage` class to handle image processing, including methods for generating image buffers, parsing metadata, and creating source sets.
* [`apps/wjt/src/scripts/blog-image/blog-image.ts`](diffhunk://#diff-849f54b6048af5e65923bab140a9b25be7bb1742dc351a25179c4153d3dc80fbR1-R107): Added a utility function `generateSrcSet` to generate responsive image source sets.

### Unit tests for `BlogImage` class:

* [`apps/wjt/src/scripts/blog-image/blog-image.spec.ts`](diffhunk://#diff-e16c06bce4cbadf8dffd8b5c9e216c61bea17d13f235169cb3e7714b6a5a17bbR1-R136): Added unit tests for the `BlogImage` class, covering various methods such as `generateImageBuffer`, `isCDNPath`, `imageMetaData`, `imageSrc`, and `sourceSet`.
* [`apps/wjt/src/scripts/blog-image/blog-image.spec.ts`](diffhunk://#diff-e16c06bce4cbadf8dffd8b5c9e216c61bea17d13f235169cb3e7714b6a5a17bbR1-R136): Included tests for the `generateSrcSet` utility function to ensure it returns the correct source set array.