### PR TITLE
chore(@wjt/markdown): adds boilerplate

### DIFF
--- a/libs/markdown/README.md
+++ b/libs/markdown/README.md
@@ -1,0 +1,7 @@
+# markdown
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test markdown` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/markdown/eslint.config.js
+++ b/libs/markdown/eslint.config.js
@@ -1,0 +1,3 @@
+const baseConfig = require('../../eslint.config.js');
+
+module.exports = [...baseConfig];

--- a/libs/markdown/jest.config.ts
+++ b/libs/markdown/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'markdown',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/markdown',
+};

--- a/libs/markdown/project.json
+++ b/libs/markdown/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "markdown",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/markdown/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project markdown --web",
+  "targets": {}
+}

--- a/libs/markdown/src/index.ts
+++ b/libs/markdown/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/markdown';

--- a/libs/markdown/src/lib/markdown.spec.ts
+++ b/libs/markdown/src/lib/markdown.spec.ts
@@ -1,0 +1,7 @@
+import { markdown } from './markdown';
+
+describe('markdown', () => {
+  it('should work', () => {
+    expect(markdown()).toEqual('markdown');
+  });
+});

--- a/libs/markdown/src/lib/markdown.ts
+++ b/libs/markdown/src/lib/markdown.ts
@@ -1,0 +1,3 @@
+export function markdown(): string {
+  return 'markdown';
+}

--- a/libs/markdown/tsconfig.json
+++ b/libs/markdown/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/markdown/tsconfig.lib.json
+++ b/libs/markdown/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/markdown/tsconfig.spec.json
+++ b/libs/markdown/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@wjt/images": ["libs/images/src/index.ts"]
+      "@wjt/images": ["libs/images/src/index.ts"],
+      "@wjt/markdown": ["libs/markdown/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
This pull request introduces a new `markdown` library to the project. The changes include adding configuration files, setting up unit tests, and exporting the initial functionality of the library.

### New Library Setup:

* [`libs/markdown/README.md`](diffhunk://#diff-a9112a79c25bed7eea0537355d33935069ab7ff23acc3162992f515fbc0af65aR1-R7): Added a README file with basic instructions for running unit tests.
* [`libs/markdown/project.json`](diffhunk://#diff-89182d3b85ea5676d5f7364750f2a7b75d25caee27fce5e5e96dc138531e0332R1-R9): Created a project configuration file for the `markdown` library.
* [`tsconfig.base.json`](diffhunk://#diff-0b280a445be167f54cd916c0718c952b8e0d4ca9621903d05eec25efd4c6ed6dL18-R19): Updated the TypeScript configuration to include the new `markdown` library.

### Configuration Files:

* [`libs/markdown/eslint.config.js`](diffhunk://#diff-d28cef02d6cea372eb019f3cc0cfed6eb63189e38ef55724a191a6f2978e3763R1-R3): Added ESLint configuration for the `markdown` library, extending the base configuration.
* [`libs/markdown/jest.config.ts`](diffhunk://#diff-662c5f88320231944b963c8c07bb30bb5f9de640c3b9647722f375be9774f7b7R1-R10): Added Jest configuration for the `markdown` library to set up unit testing.
* `libs/markdown/tsconfig.json`, `libs/markdown/tsconfig.lib.json`, `libs/markdown/tsconfig.spec.json`: Added TypeScript configuration files for the library, including base, library-specific, and test-specific configurations. [[1]](diffhunk://#diff-f263c9d6a7be1da1b274435f076c188de00b8b7d646d8cd832fecea2a37eca63R1-R16) [[2]](diffhunk://#diff-07bebd6f34d9546baa9d0f620bb72f4c89bb0ee7d057c0443151194d60e1115aR1-R11) [[3]](diffhunk://#diff-5f192a2bdcf9d9573c1def9e1a1a83c3ebe1496d81af880be825c2ee8357f3f3R1-R14)

### Initial Functionality:

* [`libs/markdown/src/index.ts`](diffhunk://#diff-5b2c903db8aceda13970793931be629a02a12ce35b9108d42a167ba1221fd6eeR1): Exported the `markdown` function from the library.
* [`libs/markdown/src/lib/markdown.ts`](diffhunk://#diff-7654a29e6b63a0465c4b1bc98c95c4531a125734ee803e036294f6063f834e50R1-R3): Implemented the `markdown` function, which currently returns a string.
* [`libs/markdown/src/lib/markdown.spec.ts`](diffhunk://#diff-455575202588e40f915c77de5ba10ef49dc7a1ee556c7fe0ce2587f79a4756b4R1-R7): Added a unit test for the `markdown` function to verify its output.