### PR TITLE
chore(@wjt/markdown): implements markdown classes

### DIFF
--- a/libs/markdown/src/index.ts
+++ b/libs/markdown/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/markdown';
+export * from './lib/Markdown';

--- a/libs/markdown/src/lib/Doc/Doc.spec.ts
+++ b/libs/markdown/src/lib/Doc/Doc.spec.ts
@@ -1,0 +1,7 @@
+import { Doc } from './Doc';
+
+describe('Doc', () => {
+  test('should be defined', () => {
+    expect(Doc).toBeDefined();
+  });
+});

--- a/libs/markdown/src/lib/Doc/Doc.ts
+++ b/libs/markdown/src/lib/Doc/Doc.ts
@@ -1,0 +1,18 @@
+import _path from 'path';
+import fs from 'fs';
+
+export abstract class Doc {
+  readonly fileExtension: string;
+  readonly path: string;
+  readonly name: string;
+  readonly value: Buffer;
+
+  updatedValue: Buffer;
+
+  constructor(filePath: string) {
+    this.path = filePath;
+    this.fileExtension = _path.extname(filePath);
+    this.name = _path.basename(filePath, this.fileExtension);
+    this.value = fs.readFileSync(filePath);
+  }
+}

--- a/libs/markdown/src/lib/Doc/Doc.ts
+++ b/libs/markdown/src/lib/Doc/Doc.ts
@@ -15,4 +15,11 @@ export abstract class Doc {
     this.name = _path.basename(filePath, this.fileExtension);
     this.value = fs.readFileSync(filePath);
   }
+
+  public abstract update(params: unknown): Promise<void>;
+
+  protected write(buffer: Buffer): Promise<void> {
+    fs.writeFileSync(this.path, buffer);
+    return;
+  }
 }

--- a/libs/markdown/src/lib/Doc/Doc.ts
+++ b/libs/markdown/src/lib/Doc/Doc.ts
@@ -8,18 +8,25 @@ export abstract class Doc {
   readonly value: Buffer;
 
   updatedValue: Buffer;
+  logger: typeof console;
 
-  constructor(filePath: string) {
+  constructor(filePath: string, logger: typeof console = console) {
     this.path = filePath;
     this.fileExtension = _path.extname(filePath);
     this.name = _path.basename(filePath, this.fileExtension);
     this.value = fs.readFileSync(filePath);
+    this.logger = logger;
   }
 
+  public abstract report(params?: unknown): Promise<void>;
   public abstract update(params: unknown): Promise<void>;
 
   protected write(buffer: Buffer): Promise<void> {
     fs.writeFileSync(this.path, buffer);
     return;
+  }
+
+  protected bufferHasValue(buffer: Buffer): boolean {
+    return buffer?.length > 0;
   }
 }

--- a/libs/markdown/src/lib/Doc/index.ts
+++ b/libs/markdown/src/lib/Doc/index.ts
@@ -1,0 +1,1 @@
+export { Doc } from './Doc';

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -3,6 +3,12 @@ import { Doc as Document } from '../Doc';
 import mock from 'mock-fs';
 import fs from 'fs';
 
+import console from 'console';
+
+const mockLogger = jest.mock('console', () => ({
+  log: jest.fn(),
+}));
+
 describe('Markdown Document', () => {
   test('should be defined', () => {
     expect(Markdown).toBeDefined();
@@ -86,6 +92,47 @@ describe('Markdown Document', () => {
       await expect(sut.update({ matcher, replacement })).rejects.toThrow(
         'Error updating path/to/file.md. No matches found using matched: /no match/'
       );
+    });
+  });
+
+  describe('report', () => {
+    const mockFileSystem = {
+      'path/to/file.md': 'report me',
+    };
+
+    beforeEach(() => {
+      mock(mockFileSystem);
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    test('should be defined', () => {
+      const sut = new Markdown('path/to/file.md');
+      expect(sut.report).toBeDefined();
+    });
+
+    test('should log original value if no updates were made', () => {
+      const sut = new Markdown('path/to/file.md');
+      const loggerSpy = jest.spyOn(sut.logger, 'log');
+
+      sut.report();
+
+      expect(loggerSpy).toHaveBeenCalledWith('report me');
+    });
+
+    test('should log updated value if updates were made', async () => {
+      const sut = new Markdown('path/to/file.md');
+      const loggerSpy = jest.spyOn(sut.logger, 'log');
+
+      const matcher = new RegExp('report me');
+      const replacement = 'reported';
+
+      await sut.update({ matcher, replacement });
+      sut.report();
+
+      expect(loggerSpy).toHaveBeenCalledWith('reported');
     });
   });
 });

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -112,17 +112,16 @@ describe('Markdown Document', () => {
     });
 
     test('should log original value if no updates were made', () => {
-      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
       const sut = new Markdown('path/to/file.md');
-      const loggerSpy = jest.spyOn(sut.logger, 'log');
 
       sut.report();
 
-      expect(loggerSpy).toHaveBeenCalledWith('report me');
+      expect(logSpy).toHaveBeenCalledWith('report me');
     });
 
     test('should log updated value if updates were made', async () => {
-      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
       const sut = new Markdown('path/to/file.md');
 
       const matcher = new RegExp('report me');
@@ -131,7 +130,7 @@ describe('Markdown Document', () => {
       await sut.update({ matcher, replacement });
       sut.report();
 
-      expect(sut.logger.log).toHaveBeenCalledWith('reported');
+      expect(logSpy).toHaveBeenCalledWith('reported');
     });
   });
 });

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -1,0 +1,48 @@
+import { Markdown } from './Markdown';
+import { Doc as Document } from '../Doc';
+import mock from 'mock-fs';
+
+describe('Markdown Document', () => {
+  test('should be defined', () => {
+    expect(Markdown).toBeDefined();
+  });
+
+  describe('Document properties', () => {
+    let sut: Markdown;
+
+    const mockFileSystem = {
+      'path/to/file.md': 'file content',
+    };
+
+    beforeEach(() => {
+      mock(mockFileSystem);
+      sut = new Markdown('path/to/file.md');
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    test('should extend Document', () => {
+      expect(Markdown.prototype).toBeInstanceOf(Document);
+    });
+
+    test('should have a path property', () => {
+      expect(sut.path).toBe('path/to/file.md');
+    });
+
+    test('should have a fileExtension property', () => {
+      expect(sut.fileExtension).toBe('.md');
+    });
+
+    test('should have a name property', () => {
+      expect(sut.name).toBe('file');
+    });
+
+    test('should have a value property', () => {
+      const expectedValue = Buffer.from('file content');
+
+      expect(sut.value).toEqual(expectedValue);
+    });
+  });
+});

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -1,6 +1,7 @@
 import { Markdown } from './Markdown';
 import { Doc as Document } from '../Doc';
 import mock from 'mock-fs';
+import fs from 'fs';
 
 describe('Markdown Document', () => {
   test('should be defined', () => {
@@ -43,6 +44,48 @@ describe('Markdown Document', () => {
       const expectedValue = Buffer.from('file content');
 
       expect(sut.value).toEqual(expectedValue);
+    });
+  });
+
+  describe('update', () => {
+    let sut: Markdown;
+
+    const mockFileSystem = {
+      'path/to/file.md': 'update me',
+    };
+
+    beforeEach(() => {
+      mock(mockFileSystem);
+      sut = new Markdown('path/to/file.md');
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    test('should be defined', () => {
+      expect(sut.update).toBeDefined();
+    });
+
+    test('should update the document', async () => {
+      const matcher = new RegExp('update me');
+      const replacement = 'updated';
+
+      await sut.update({ matcher, replacement });
+
+      const expectedValue = Buffer.from('updated');
+      const value = fs.readFileSync('path/to/file.md');
+
+      expect(value).toEqual(expectedValue);
+    });
+
+    test('should throw an error if there are no matches', async () => {
+      const matcher = new RegExp('no match');
+      const replacement = 'updated';
+
+      await expect(sut.update({ matcher, replacement })).rejects.toThrow(
+        'Error updating path/to/file.md. No matches found using matched: /no match/'
+      );
     });
   });
 });

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -3,12 +3,6 @@ import { Doc as Document } from '../Doc';
 import mock from 'mock-fs';
 import fs from 'fs';
 
-import console from 'console';
-
-const mockLogger = jest.mock('console', () => ({
-  log: jest.fn(),
-}));
-
 describe('Markdown Document', () => {
   test('should be defined', () => {
     expect(Markdown).toBeDefined();
@@ -61,8 +55,12 @@ describe('Markdown Document', () => {
     };
 
     beforeEach(() => {
+      const mockLogger = jest.fn();
       mock(mockFileSystem);
-      sut = new Markdown('path/to/file.md');
+      sut = new Markdown(
+        'path/to/file.md',
+        mockLogger as unknown as typeof console
+      );
     });
 
     afterEach(() => {
@@ -90,7 +88,7 @@ describe('Markdown Document', () => {
       const replacement = 'updated';
 
       await expect(sut.update({ matcher, replacement })).rejects.toThrow(
-        'Error updating path/to/file.md. No matches found using matched: /no match/'
+        'Error updating path/to/file.md. No matches found using matcher: /no match/'
       );
     });
   });
@@ -114,6 +112,7 @@ describe('Markdown Document', () => {
     });
 
     test('should log original value if no updates were made', () => {
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
       const sut = new Markdown('path/to/file.md');
       const loggerSpy = jest.spyOn(sut.logger, 'log');
 
@@ -123,8 +122,8 @@ describe('Markdown Document', () => {
     });
 
     test('should log updated value if updates were made', async () => {
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
       const sut = new Markdown('path/to/file.md');
-      const loggerSpy = jest.spyOn(sut.logger, 'log');
 
       const matcher = new RegExp('report me');
       const replacement = 'reported';
@@ -132,7 +131,7 @@ describe('Markdown Document', () => {
       await sut.update({ matcher, replacement });
       sut.report();
 
-      expect(loggerSpy).toHaveBeenCalledWith('reported');
+      expect(sut.logger.log).toHaveBeenCalledWith('reported');
     });
   });
 });

--- a/libs/markdown/src/lib/Markdown/Markdown.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.ts
@@ -1,7 +1,27 @@
 import { Doc as Document } from '../Doc';
 
+type MarkdownUpdateParams = {
+  matcher: RegExp;
+  replacement: string;
+};
 export class Markdown extends Document {
   constructor(filePath: string) {
     super(filePath);
+  }
+
+  public async update({
+    matcher,
+    replacement,
+  }: MarkdownUpdateParams): Promise<void> {
+    const updatedValue = this.value.toString().replace(matcher, replacement);
+
+    if (updatedValue === this.value.toString()) {
+      throw new Error(
+        `Error updating ${this.path}. No matches found using matched: ${matcher}`
+      );
+    }
+
+    this.updatedValue = Buffer.from(updatedValue);
+    this.write(this.updatedValue);
   }
 }

--- a/libs/markdown/src/lib/Markdown/Markdown.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.ts
@@ -1,0 +1,7 @@
+import { Doc as Document } from '../Doc';
+
+export class Markdown extends Document {
+  constructor(filePath: string) {
+    super(filePath);
+  }
+}

--- a/libs/markdown/src/lib/Markdown/Markdown.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.ts
@@ -5,8 +5,8 @@ type MarkdownUpdateParams = {
   replacement: string;
 };
 export class Markdown extends Document {
-  constructor(filePath: string) {
-    super(filePath);
+  constructor(filePath: string, logger: typeof console = console) {
+    super(filePath, logger);
   }
 
   /**
@@ -22,7 +22,7 @@ export class Markdown extends Document {
 
     if (updatedValue === this.value.toString()) {
       throw new Error(
-        `Error updating ${this.path}. No matches found using matched: ${matcher}`
+        `Error updating ${this.path}. No matches found using matcher: ${matcher}`
       );
     }
 

--- a/libs/markdown/src/lib/Markdown/Markdown.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.ts
@@ -9,6 +9,11 @@ export class Markdown extends Document {
     super(filePath);
   }
 
+  /**
+   * Accepts a matcher and a replacement value and writes the updated value to the file
+   * @param {MarkdownUpdateParams} { matcher, replacement }
+   * @returns {Promise<void>}
+   */
   public async update({
     matcher,
     replacement,
@@ -23,5 +28,20 @@ export class Markdown extends Document {
 
     this.updatedValue = Buffer.from(updatedValue);
     this.write(this.updatedValue);
+  }
+
+  /**
+   * Logs the current value of the target markdown document
+   * @returns {Promise<void>}
+   */
+  public async report(): Promise<void> {
+    const isUpdated = this.bufferHasValue(this.updatedValue);
+
+    if (isUpdated) {
+      this.logger.log(this.updatedValue.toString());
+      return;
+    }
+
+    this.logger.log(this.value.toString());
   }
 }

--- a/libs/markdown/src/lib/Markdown/index.ts
+++ b/libs/markdown/src/lib/Markdown/index.ts
@@ -1,0 +1,1 @@
+export * from './Markdown';

--- a/libs/markdown/src/lib/markdown.spec.ts
+++ b/libs/markdown/src/lib/markdown.spec.ts
@@ -1,7 +1,0 @@
-import { markdown } from './markdown';
-
-describe('markdown', () => {
-  it('should work', () => {
-    expect(markdown()).toEqual('markdown');
-  });
-});

--- a/libs/markdown/src/lib/markdown.ts
+++ b/libs/markdown/src/lib/markdown.ts
@@ -1,3 +1,0 @@
-export function markdown(): string {
-  return 'markdown';
-}

--- a/libs/markdown/tsconfig.json
+++ b/libs/markdown/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "esModuleInterop": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
This pull request introduces a new abstract class `Doc` and a `Markdown` class that extends it, along with corresponding tests and some cleanup of old code. The most important changes include the creation of these classes, their methods, and the tests to ensure their functionality.

### Introduction of `Doc` and `Markdown` classes:

* [`libs/markdown/src/lib/Doc/Doc.ts`](diffhunk://#diff-deb79b513dd67b9d96498d2ee5641ba596d84343f5b23e3cc4e036ada12c90b8R1-R32): Added the `Doc` abstract class with properties and methods for handling document files, including `report` and `update` methods.
* [`libs/markdown/src/lib/Markdown/Markdown.ts`](diffhunk://#diff-e7d3206d2be855707bbe5648c87f6668529d3a230ef65120e891db0c4691472bR1-R47): Added the `Markdown` class that extends `Doc` and implements the `update` and `report` methods specific to markdown files.

### Testing:

* [`libs/markdown/src/lib/Doc/Doc.spec.ts`](diffhunk://#diff-ff7b142b7b490cd7dbb6fe8c4ea1cee11d6b70bf8c1b1fbd6a6c7fb40db20843R1-R7): Added tests for the `Doc` class to ensure it is defined.
* [`libs/markdown/src/lib/Markdown/Markdown.spec.ts`](diffhunk://#diff-0b4f0958cbb2b2d44aecae8463a79f920ca06ab8b734f78f4765d4c4891eebc8R1-R138): Added comprehensive tests for the `Markdown` class, including tests for document properties, the `update` method, and the `report` method.

### Code cleanup:

* [`libs/markdown/src/lib/Doc/index.ts`](diffhunk://#diff-b958648494d1c791bf0c12b76302137964eea4ea8b2516756e3933efd1bc64c8R1): Exported the `Doc` class.
* [`libs/markdown/src/lib/markdown.spec.ts`](diffhunk://#diff-455575202588e40f915c77de5ba10ef49dc7a1ee556c7fe0ce2587f79a4756b4L1-L7): Removed old tests for the obsolete `markdown` function.
* [`libs/markdown/src/lib/markdown.ts`](diffhunk://#diff-7654a29e6b63a0465c4b1bc98c95c4531a125734ee803e036294f6063f834e50L1-L3): Removed the obsolete `markdown` function.

### Configuration:

* [`libs/markdown/tsconfig.json`](diffhunk://#diff-f263c9d6a7be1da1b274435f076c188de00b8b7d646d8cd832fecea2a37eca63L4-R5): Updated TypeScript configuration to include `esModuleInterop`.

Closes #88 