### PR TITLE
chore(@wjt/blog): wjt-94 - implements raw post

### DIFF
--- a/libs/blog/src/index.ts
+++ b/libs/blog/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/blog';
+export * from './lib/RawPost';

--- a/libs/blog/src/lib/RawPost/RawPost.spec.ts
+++ b/libs/blog/src/lib/RawPost/RawPost.spec.ts
@@ -1,0 +1,56 @@
+import { RawPost } from './RawPost';
+import { MockRawPostFileSystem, RawPostPaths } from './RawPostMocks';
+
+import mock from 'mock-fs';
+
+describe('RawPost', () => {
+  let sut: RawPost;
+
+  beforeEach(() => {
+    mock(MockRawPostFileSystem);
+    sut = new RawPost(RawPostPaths.LOCAL);
+  });
+
+  afterEach(() => {
+    mock.restore();
+    jest.restoreAllMocks();
+  });
+
+  test('should be defined', () => {
+    expect(RawPost).toBeDefined();
+  });
+
+  describe('imageNodes', () => {
+    test('should be defined', () => {
+      expect(sut.imageNodes).toBeDefined();
+    });
+
+    test('should have image nodes', () => {
+      expect(sut.imageNodes).toHaveLength(1);
+    });
+  });
+
+  describe('originalContent', () => {
+    test('should be defined', () => {
+      expect(sut.originalContent).toBeDefined();
+    });
+
+    test('should have the correct original content', () => {
+      const expectedContent = MockRawPostFileSystem[RawPostPaths.LOCAL];
+
+      expect(sut.originalContent).toEqual(expectedContent);
+    });
+  });
+
+  describe('rawFrontMatter', () => {
+    test('should be defined', () => {
+      expect(sut.rawFrontMatter).toBeDefined();
+    });
+
+    test('should return the correct raw frontmatter string', () => {
+      const expectedFrontMatter = `---\ntitle: My Example Post\nauthor: Will Johnston\nslug: example-post\n---`;
+
+      expect(sut.rawFrontMatter).toEqual(expectedFrontMatter);
+    });
+  });
+});

--- a/libs/blog/src/lib/RawPost/RawPost.ts
+++ b/libs/blog/src/lib/RawPost/RawPost.ts
@@ -1,0 +1,28 @@
+import { Markdown, CommonmarkNode } from '@wjt/markdown';
+
+export class RawPost extends Markdown {
+  private readonly frontmatterMatcher = /---([\s\S]*?)---/;
+
+  readonly imageNodes: CommonmarkNode[] = [];
+  readonly originalContent: string;
+
+  private updatedContent: string;
+
+  constructor(filePath: string, logger: typeof console = console) {
+    super(filePath, logger);
+
+    this.imageNodes = this.getNodesByType('image');
+    this.originalContent = this.value.toString();
+  }
+
+  /**
+   * Returns the frontmatter of the post
+   * @returns {string}
+   */
+  get rawFrontMatter(): string {
+    const content = this.updatedContent || this.originalContent;
+    const [frontMatter] = content.match(this.frontmatterMatcher);
+
+    return frontMatter;
+  }
+}

--- a/libs/blog/src/lib/RawPost/RawPostMocks.ts
+++ b/libs/blog/src/lib/RawPost/RawPostMocks.ts
@@ -1,0 +1,25 @@
+const rawPostLocal = `---
+title: My Example Post
+author: Will Johnston
+slug: example-post
+---
+
+# Example Post
+
+This is a local post. That means it's images are stored in the local filesystem and have not been uploaded to the CDN.
+
+![Sample Image](./local/sample-image.png)
+
+`;
+
+export const RawPostMocks = {
+  LOCAL: rawPostLocal,
+};
+
+export const RawPostPaths = {
+  LOCAL: '/posts/local-post.md',
+};
+
+export const MockRawPostFileSystem = {
+  [RawPostPaths.LOCAL]: RawPostMocks.LOCAL,
+};

--- a/libs/blog/src/lib/RawPost/index.ts
+++ b/libs/blog/src/lib/RawPost/index.ts
@@ -1,0 +1,1 @@
+export * from './RawPost';

--- a/libs/blog/src/lib/blog.spec.ts
+++ b/libs/blog/src/lib/blog.spec.ts
@@ -1,7 +1,0 @@
-import { blog } from './blog';
-
-describe('blog', () => {
-  it('should work', () => {
-    expect(blog()).toEqual('blog');
-  });
-});

--- a/libs/blog/src/lib/blog.ts
+++ b/libs/blog/src/lib/blog.ts
@@ -1,3 +1,0 @@
-export function blog(): string {
-  return 'blog';
-}

--- a/libs/blog/tsconfig.json
+++ b/libs/blog/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "esModuleInterop": true
   },
   "files": [],
   "include": [],

--- a/libs/markdown/src/lib/Doc/Doc.ts
+++ b/libs/markdown/src/lib/Doc/Doc.ts
@@ -21,15 +21,29 @@ export abstract class Doc {
   public abstract report(params?: unknown): Promise<void>;
   public abstract update(params: unknown): Promise<void>;
 
+  /**
+   * Writes the buffer to the file
+   * @param {Buffer }buffer
+   * @returns {Promise<void>}
+   */
   protected write(buffer: Buffer): Promise<void> {
     fs.writeFileSync(this.path, buffer);
     return;
   }
 
+  /**
+   * Determines if the buffer has a value
+   * @param {Buffer} buffer
+   * @returns {boolean}
+   */
   protected bufferHasValue(buffer: Buffer): boolean {
     return buffer?.length > 0;
   }
 
+  /**
+   * Returns the string value of the buffer
+   * @returns {string}
+   */
   public toString(): string {
     return this.value.toString();
   }

--- a/libs/markdown/src/lib/Doc/Doc.ts
+++ b/libs/markdown/src/lib/Doc/Doc.ts
@@ -29,4 +29,8 @@ export abstract class Doc {
   protected bufferHasValue(buffer: Buffer): boolean {
     return buffer?.length > 0;
   }
+
+  public toString(): string {
+    return this.value.toString();
+  }
 }

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -233,7 +233,7 @@ describe('Markdown Document', () => {
     });
 
     test('should return the correct nodes', () => {
-      var targetNodes = sut.getNodesByType('image');
+      let targetNodes = sut.getNodesByType('image');
 
       expect(targetNodes).toHaveLength(1);
       expect(targetNodes[0].type).toBe('image');

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -2,6 +2,7 @@ import { Markdown } from './Markdown';
 import { Doc as Document } from '../Doc';
 import mock from 'mock-fs';
 import fs from 'fs';
+import { Node as CommonmarkNode } from 'commonmark';
 
 describe('Markdown Document', () => {
   test('should be defined', () => {
@@ -131,6 +132,80 @@ describe('Markdown Document', () => {
       sut.report();
 
       expect(logSpy).toHaveBeenCalledWith('reported');
+    });
+  });
+
+  describe('parse', () => {
+    let sut: Markdown;
+
+    const mockFileSystem = {
+      'path/to/file.md': 'update me',
+    };
+
+    beforeEach(() => {
+      const mockLogger = jest.fn();
+      mock(mockFileSystem);
+
+      sut = new Markdown(
+        'path/to/file.md',
+        mockLogger as unknown as typeof console
+      );
+    });
+
+    afterEach(() => {
+      mock.restore();
+      jest.restoreAllMocks();
+    });
+
+    test('should be defined', () => {
+      expect(sut.parse).toBeDefined();
+    });
+
+    test('should parse the markdown document into an AST', () => {
+      sut.parse();
+
+      expect(sut.AST).toBeDefined();
+      expect(sut.AST).toBeInstanceOf(CommonmarkNode);
+    });
+  });
+
+  describe('toString', () => {
+    let sut: Markdown;
+
+    const mockFileSystem = {
+      'path/to/file.md': 'update me',
+    };
+
+    beforeEach(() => {
+      const mockLogger = jest.fn();
+      mock(mockFileSystem);
+
+      sut = new Markdown(
+        'path/to/file.md',
+        mockLogger as unknown as typeof console
+      );
+    });
+
+    afterEach(() => {
+      mock.restore();
+      jest.restoreAllMocks();
+    });
+
+    test('should be defined', () => {
+      expect(sut.toString).toBeDefined();
+    });
+
+    test('should return the original value if no updates were made', () => {
+      expect(sut.toString()).toBe('update me');
+    });
+
+    test('should return the updated value if it exists', async () => {
+      const matcher = new RegExp('update me');
+      const replacement = 'updated';
+
+      await sut.update({ matcher, replacement });
+
+      expect(sut.toString()).toBe('updated');
     });
   });
 });

--- a/libs/markdown/src/lib/Markdown/Markdown.spec.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.spec.ts
@@ -2,7 +2,7 @@ import { Markdown } from './Markdown';
 import { Doc as Document } from '../Doc';
 import mock from 'mock-fs';
 import fs from 'fs';
-import { Node as CommonmarkNode } from 'commonmark';
+import { Node as CommonmarkNode, NodeType } from 'commonmark';
 
 describe('Markdown Document', () => {
   test('should be defined', () => {
@@ -206,6 +206,41 @@ describe('Markdown Document', () => {
       await sut.update({ matcher, replacement });
 
       expect(sut.toString()).toBe('updated');
+    });
+  });
+
+  describe('getNodesByType', () => {
+    let sut: Markdown;
+
+    const markdownFile = `# Heading 1 \n\n![alt text](image.jpg)`;
+
+    const mockFileSystem = {
+      'path/to/file.md': markdownFile,
+      'path/to/image.jpg': Buffer.from('image content'),
+    };
+
+    beforeEach(() => {
+      mock(mockFileSystem);
+      sut = new Markdown('path/to/file.md');
+    });
+
+    afterEach(() => {
+      mock.restore();
+    });
+
+    test('should be defined', () => {
+      expect(sut.getNodesByType).toBeDefined();
+    });
+
+    test('should return the correct nodes', () => {
+      var targetNodes = sut.getNodesByType('image');
+
+      expect(targetNodes).toHaveLength(1);
+      expect(targetNodes[0].type).toBe('image');
+
+      targetNodes = sut.getNodesByType('heading');
+      expect(targetNodes).toHaveLength(1);
+      expect(targetNodes[0].type).toBe('heading');
     });
   });
 });

--- a/libs/markdown/src/lib/Markdown/Markdown.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.ts
@@ -1,12 +1,24 @@
 import { Doc as Document } from '../Doc';
 
+import { Parser, Node as CommonmarkNode } from 'commonmark';
+
 type MarkdownUpdateParams = {
   matcher: RegExp;
   replacement: string;
 };
+
 export class Markdown extends Document {
-  constructor(filePath: string, logger: typeof console = console) {
+  private parser: Parser;
+  public AST: CommonmarkNode;
+
+  constructor(
+    filePath: string,
+    logger: typeof console = console,
+    parser: Parser = new Parser()
+  ) {
     super(filePath, logger);
+
+    this.parser = parser;
   }
 
   /**
@@ -43,5 +55,30 @@ export class Markdown extends Document {
     }
 
     this.logger.log(this.value.toString());
+  }
+
+  /**
+   * Parses the markdown document into an AST
+   */
+  public parse(): void {
+    const input = this.toString();
+
+    this.AST = this.parser.parse(input);
+  }
+
+  /**
+   * Returns the string representation of the markdown document with the latest values
+   * @returns {string}
+   */
+  override toString(): string {
+    if (this.hasUpdatedValue()) {
+      return this.updatedValue.toString();
+    }
+
+    return this.value.toString();
+  }
+
+  private hasUpdatedValue(): boolean {
+    return this.bufferHasValue(this.updatedValue);
   }
 }

--- a/libs/markdown/src/lib/Markdown/Markdown.ts
+++ b/libs/markdown/src/lib/Markdown/Markdown.ts
@@ -1,20 +1,24 @@
 import { Doc as Document } from '../Doc';
 
-import { Parser, Node as CommonmarkNode, NodeType } from 'commonmark';
+import { Parser, Node, NodeType } from 'commonmark';
 
 type MarkdownUpdateParams = {
   matcher: RegExp;
   replacement: string;
 };
 
+export type CommonmarkNode = Node;
+export type CommonmarkNodeType = NodeType;
+export type CommonmarkParser = Parser;
+
 export class Markdown extends Document {
-  private parser: Parser;
+  private parser: CommonmarkParser;
   public AST: CommonmarkNode;
 
   constructor(
     filePath: string,
     logger: typeof console = console,
-    parser: Parser = new Parser()
+    parser: CommonmarkParser = new Parser()
   ) {
     super(filePath, logger);
 
@@ -89,10 +93,10 @@ export class Markdown extends Document {
 
   /**
    * Returns the Commonmark nodes of the given type from the document
-   * @param {NodeType} type
+   * @param {CommonmarkNodeType} type
    * @returns {CommonmarkNode[]}
    */
-  public getNodesByType(type: NodeType): CommonmarkNode[] {
+  public getNodesByType(type: CommonmarkNodeType): CommonmarkNode[] {
     const nodes: CommonmarkNode[] = [];
 
     const walker = this.AST.walker();


### PR DESCRIPTION
This pull request includes significant updates to the `libs/blog` and `libs/markdown` modules. The changes introduce a new `RawPost` class, enhance the `Markdown` class with additional functionality, and update the test coverage accordingly.

### Introduction of `RawPost` class:
* [`libs/blog/src/index.ts`](diffhunk://#diff-520c818057cfd1d9b33c29e3dfb90f1136b7e5ba381e30e62c09ada6a341bb18L1-R1): Changed export to include `RawPost` instead of `blog`.
* [`libs/blog/src/lib/RawPost/RawPost.ts`](diffhunk://#diff-6f1a58291ad21d16e4fde079a2a0cc724b9186c6f4cb90c6a04f1cf38f69ca7fR1-R28): Added a new `RawPost` class extending `Markdown` with methods to handle frontmatter and image nodes.
* [`libs/blog/src/lib/RawPost/RawPost.spec.ts`](diffhunk://#diff-22c21da70f243cb78146f2f2536662e2e9aed13dc45acb3804765f66240861f7R1-R56): Added tests for the `RawPost` class, including checks for frontmatter, image nodes, and original content.
* [`libs/blog/src/lib/RawPost/RawPostMocks.ts`](diffhunk://#diff-28da42582bee213c9de4bfe379a487cb5de64b73c29dcb0dce2b6d2f800b6da8R1-R25): Added mock data for `RawPost` tests.
* [`libs/blog/src/lib/RawPost/index.ts`](diffhunk://#diff-9c3086629bac9170b9291e8ea4f45efbc81ca7d1e492cd0ec7de28fc8b935390R1): Exported the `RawPost` class.

### Enhancements to `Markdown` class:
* [`libs/markdown/src/lib/Doc/Doc.ts`](diffhunk://#diff-deb79b513dd67b9d96498d2ee5641ba596d84343f5b23e3cc4e036ada12c90b8R32-R35): Added a `toString` method to the `Doc` class.
* [`libs/markdown/src/lib/Markdown/Markdown.ts`](diffhunk://#diff-e7d3206d2be855707bbe5648c87f6668529d3a230ef65120e891db0c4691472bR3-R26): Enhanced `Markdown` class with parsing capabilities, AST generation, and methods to retrieve nodes by type. [[1]](diffhunk://#diff-e7d3206d2be855707bbe5648c87f6668529d3a230ef65120e891db0c4691472bR3-R26) [[2]](diffhunk://#diff-e7d3206d2be855707bbe5648c87f6668529d3a230ef65120e891db0c4691472bR64-R130)
* [`libs/markdown/src/lib/Markdown/Markdown.spec.ts`](diffhunk://#diff-0b4f0958cbb2b2d44aecae8463a79f920ca06ab8b734f78f4765d4c4891eebc8R5): Added tests for the new methods in `Markdown`, including parsing, `toString`, and `getNodesByType`. [[1]](diffhunk://#diff-0b4f0958cbb2b2d44aecae8463a79f920ca06ab8b734f78f4765d4c4891eebc8R5) [[2]](diffhunk://#diff-0b4f0958cbb2b2d44aecae8463a79f920ca06ab8b734f78f4765d4c4891eebc8R137-R245)

### Other updates:
* [`libs/blog/tsconfig.json`](diffhunk://#diff-d0581b1c059ad24862eeeeff2ffa9e4c2741ac1e752c348ba8ddce8b3e47a2a1L4-R5): Enabled `esModuleInterop` in TypeScript configuration.
* [`libs/blog/src/lib/blog.spec.ts`](diffhunk://#diff-86ec7b1dbefec6cc500352a4bed68422fe06d4ecd932eddb4d0f768aaa30f06dL1-L7): Removed obsolete tests for the `blog` function.
* [`libs/blog/src/lib/blog.ts`](diffhunk://#diff-a882d1f63c5623ea17484903a9c1082473fb1da1829d6e1db44158b5b7d20671L1-L3): Removed the obsolete `blog` function.